### PR TITLE
4 implement timer attribute

### DIFF
--- a/src/main/java/com/retroscore/controller/SettingsController.java
+++ b/src/main/java/com/retroscore/controller/SettingsController.java
@@ -64,6 +64,20 @@ public class SettingsController {
         }
     }
 
+    @PatchMapping("/timeLimit")
+    public ResponseEntity<Void> updateTimeLimit(@AuthenticationPrincipal UserPrincipal principal,
+                                                     @RequestParam String timeLimit){
+        try {
+            Long userId = principal.getUserId();
+            userService.updateTimeLimit(userId, timeLimit);
+            return ResponseEntity.ok().build();
+        } catch (EntityNotFoundException e){
+            return ResponseEntity.notFound().build();
+        }catch (Exception e){
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+
     @PatchMapping("/notifications")
     public ResponseEntity<Void> updateNotifications(@AuthenticationPrincipal UserPrincipal principal,
                                                      @RequestParam Boolean enabled ){

--- a/src/main/java/com/retroscore/controller/SettingsController.java
+++ b/src/main/java/com/retroscore/controller/SettingsController.java
@@ -37,7 +37,8 @@ public class SettingsController {
     }
 
     @PutMapping
-    public  ResponseEntity<UserSettingsDto> updateUserSettings(@AuthenticationPrincipal UserPrincipal principal, @RequestBody UserSettingsDto settingsDto){
+    public  ResponseEntity<UserSettingsDto> updateUserSettings(@AuthenticationPrincipal UserPrincipal principal,
+                                                               @RequestBody UserSettingsDto settingsDto){
         try {
            Long userId = principal.getUserId();
            UserSettingsDto updatedSettings = userService.updateUserSettings(userId, settingsDto);

--- a/src/main/java/com/retroscore/dto/UserGuessDto.java
+++ b/src/main/java/com/retroscore/dto/UserGuessDto.java
@@ -18,12 +18,15 @@ public class UserGuessDto {
     @Min(value = 0,message = "Away score must be non negative")
     private Integer predictedAwayScore;
 
+    private Boolean timeIsUp = false;
+
     public UserGuessDto(){}
 
-    public UserGuessDto(Long matchId, Integer predictedHomeScore, Integer predictedAwayScore){
+    public UserGuessDto(Long matchId, Integer predictedHomeScore, Integer predictedAwayScore,Boolean timeIsUp){
         this.matchId = matchId;
         this.predictedHomeScore = predictedHomeScore;
         this.predictedAwayScore = predictedAwayScore;
+        this.timeIsUp = timeIsUp;
     }
 
     @Override
@@ -32,6 +35,7 @@ public class UserGuessDto {
                 "matchId="  +matchId+
                 "predictedHomeScore="+ predictedHomeScore+
                 "predictedAwayScore="+ predictedAwayScore+
+                "timeIsUp=+"+timeIsUp+
                 "}";
     }
 

--- a/src/main/java/com/retroscore/dto/UserSettingsDto.java
+++ b/src/main/java/com/retroscore/dto/UserSettingsDto.java
@@ -1,6 +1,7 @@
 package com.retroscore.dto;
 
 import com.retroscore.enums.GameDifficulty;
+import com.retroscore.enums.TimerDurations;
 import lombok.Data;
 
 @Data
@@ -11,14 +12,14 @@ public class UserSettingsDto {
     private String preferredLeague;
     private boolean showHints;
     private GameDifficulty gameDifficulty;
-    private int timeLimit;
+    private TimerDurations timeLimit;
 
 
     public UserSettingsDto() {
 
     }
 
-    public UserSettingsDto(boolean notificationsEnabled, boolean matchReminders, boolean scoreUpdates, String preferredLeague, boolean showHints, GameDifficulty gameDifficulty, int timeLimit) {
+    public UserSettingsDto(boolean notificationsEnabled, boolean matchReminders, boolean scoreUpdates, String preferredLeague, boolean showHints, GameDifficulty gameDifficulty, TimerDurations timeLimit) {
         this.notificationsEnabled = notificationsEnabled;
         this.matchReminders = matchReminders;
         this.scoreUpdates = scoreUpdates;

--- a/src/main/java/com/retroscore/entity/User.java
+++ b/src/main/java/com/retroscore/entity/User.java
@@ -1,6 +1,7 @@
 package com.retroscore.entity;
 
 import com.retroscore.enums.GameDifficulty;
+import com.retroscore.enums.TimerDurations;
 import jakarta.persistence.*;
 import lombok.Data;
 import org.springframework.security.core.GrantedAuthority;
@@ -25,7 +26,6 @@ public class User {
     @Column(name = "provider")
     private String provider;
 
-    // Name fields (if not already present)
     @Column(name = "first_name")
     private String firstName;
 
@@ -33,19 +33,13 @@ public class User {
     private String lastName;
 
     @Column(name = "name")
-    private String name; // Full name from Google
+    private String name;
 
-    // Account status fields (if not already present)
     @Column(name = "active")
     private boolean active = true;
 
     @Column(name = "account_non_locked")
     private boolean accountNonLocked = true;
-
-/*
-    @Column(nullable = false)
-    private String passwordHash;
-*/
 
     @Column(name="google_id", nullable = true, unique = true)
     private String googleId;
@@ -65,11 +59,9 @@ public class User {
     @Column(name = "games_lost", nullable = false)
     private  Integer gamesLost = 0;
 
-    // to represent when get correct result but not exact correct score
     @Column(name = "games_draw", nullable = false)
     private  Integer gamesDrawn = 0;
 
-    //Win percentage
     public  Double getWinPercentage(){
         return gamesPlayed > 0 ? (gamesWon * 100)/ gamesPlayed : 0.0;
     }
@@ -102,8 +94,9 @@ public class User {
     @Column(name = "show_hints")
     private  boolean showHints = true;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "time_limit")
-    private int timeLimit = 5;
+    private TimerDurations timeLimit = TimerDurations.getDefault();
 
     @Column(name = "total_points", nullable = false)
     private Integer totalPoints = 0;
@@ -114,16 +107,13 @@ public class User {
     @Column(name = "correct_result_predictions", nullable = false)
     private Integer correctResultPredictions = 0;
 
+    /**
+     Exact score = 3 points(win)
+     Correct result = 1 point(draw)
+     */
     public Integer calculateTotalPoints() {
-        // Exact score = 3 points
-        // Correct result = 1 point
         return (exactScorePredictions * 3) + (correctResultPredictions);
     }
-
-    // Update win percentage calculation to be more accurate
-//    public Double getWinPercentage() {
-//        return gamesPlayed > 0 ? ((double) gamesWon / gamesPlayed) * 100.0 : 0.0;
-//    }
 
     public User() {
     }
@@ -131,7 +121,6 @@ public class User {
     public User(String username, String email) {
         this.username = username;
         this.email = email;
-//        this.passwordHash = passwordHash;
         this.createdAt = LocalDateTime.now();
         this.lastLogin = LocalDateTime.now();
 

--- a/src/main/java/com/retroscore/enums/GameResult.java
+++ b/src/main/java/com/retroscore/enums/GameResult.java
@@ -7,7 +7,8 @@ import lombok.Getter;
 public enum GameResult {
     EXACT_SCORE(3, "Perfect 3 points! Exact score !"),
     CORRECT_RESULT(1, "Good 1 point! Correct result"),
-    INCORRECT(0, "Wrong guess, try again!");
+    INCORRECT(0, "Wrong guess, try again!"),
+    TIMEUP(0, "Sorry time ran out, Try again");
 
     private final int points;
     private final String message;

--- a/src/main/java/com/retroscore/enums/TimerDurations.java
+++ b/src/main/java/com/retroscore/enums/TimerDurations.java
@@ -1,0 +1,27 @@
+package com.retroscore.enums;
+
+
+import lombok.Getter;
+
+@Getter
+public enum TimerDurations {
+
+    TEN_SECONDS(10, "10 seconds"),
+    FIFTEEN_SECONDS(15, "15 seconds"),
+    TWENTY_SECONDS(20, "20 seconds"),
+    TWENTY_FIVE_SECONDS(25, "25 seconds"),
+    THIRTY_SECONDS(30, "30 seconds"),
+    FORTY_FIVE_SECONDS(45, "45 seconds");
+
+    private final int seconds;
+    private final String displayName;
+
+    TimerDurations(int seconds, String displayName) {
+        this.seconds = seconds;
+        this.displayName = displayName;
+    }
+
+    public static TimerDurations getDefault() {
+        return THIRTY_SECONDS;
+    }
+}

--- a/src/main/java/com/retroscore/security/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/retroscore/security/OAuth2AuthenticationSuccessHandler.java
@@ -85,6 +85,7 @@ public class OAuth2AuthenticationSuccessHandler implements AuthenticationSuccess
         userData.put("email", user.getEmail());
         userData.put("username", user.getUsername() != null ? user.getUsername() : "");
         userData.put("id", user.getId());
+        userData.put("time_limit", user.getTimeLimit());
 
         try {
             String userDataJson = objectMapper.writeValueAsString(userData);

--- a/src/main/java/com/retroscore/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/retroscore/service/CustomOAuth2UserService.java
@@ -3,6 +3,7 @@ package com.retroscore.service;
 import com.retroscore.controller.AuthController;
 import com.retroscore.entity.User;
 import com.retroscore.enums.GameDifficulty;
+import com.retroscore.enums.TimerDurations;
 import com.retroscore.repository.UserRepository;
 import com.retroscore.security.UserPrincipal;
 import org.slf4j.Logger;
@@ -80,7 +81,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
          newUser.setCorrectResultPredictions(0);
          newUser.setGameDifficulty(GameDifficulty.MEDIUM);
          newUser.setPreferredLeague("ALL");
-         newUser.setTimeLimit(5);
+         newUser.setTimeLimit(TimerDurations.getDefault());
          newUser.setShowHints(true);
          newUser.setNotificationsEnabled(true);
          newUser.setMatchReminders(true);

--- a/src/main/java/com/retroscore/service/GameService.java
+++ b/src/main/java/com/retroscore/service/GameService.java
@@ -172,8 +172,27 @@ public class GameService {
         // validate user exists
         User user = userRepository.findById(userId).orElseThrow(()-> new RuntimeException("User not found"));
 
+
         // validate the match exists
         Match match = matchRepository.findById(userGuess.getMatchId()).orElseThrow(()-> new MatchNotFoundException(userGuess.getMatchId()));
+
+        // user failed to submit a guess in time, we don't record it as a user game
+        if (userGuess.getTimeIsUp() == true){
+            return UserGameResponse.builder()
+                    .matchId(match.getId())
+                    .matchTitle(match.getMatchTitle())
+                    .actualHomeScore(match.getHomeScore())
+                    .actualAwayScore(match.getAwayScore())
+                    .isCorrectScore(false)
+                    .isCorrectResult(false)
+                    .gameResult(GameResult.INCORRECT)
+                    .playedAt(LocalDateTime.now())
+                    .resultMessage(GameResult.TIMEUP.getMessage())
+                    .userGamePoints(GameResult.TIMEUP.getPoints())
+                    .build();
+
+        }
+
 
         // check if user has played the specific match before
         Optional<UserGame> existingUserGame = userGameRepository.findByUserIdAndMatchId(userId, match.getId());

--- a/src/main/java/com/retroscore/service/UserService.java
+++ b/src/main/java/com/retroscore/service/UserService.java
@@ -5,6 +5,7 @@ import com.retroscore.dto.GoogleUserInfo;
 import com.retroscore.dto.UserSettingsDto;
 import com.retroscore.entity.User;
 import com.retroscore.enums.GameDifficulty;
+import com.retroscore.enums.TimerDurations;
 import com.retroscore.repository.UserRepository;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.transaction.Transactional;
@@ -89,6 +90,16 @@ public class UserService {
             throw new EntityNotFoundException("user not found");
         }
         user.setGameDifficulty(GameDifficulty.valueOf(difficulty.toUpperCase()));
+        updateUser(user);
+
+    }
+
+    public void updateTimeLimit(Long userId, String timeLimit){
+        User user = findById(userId);
+        if(user == null){
+            throw new EntityNotFoundException("user not found");
+        }
+        user.setTimeLimit(TimerDurations.valueOf(timeLimit.toUpperCase()));
         updateUser(user);
 
     }


### PR DESCRIPTION
# Add Timer Duration Feature for User Game Sessions

## Summary
Implemented a timer duration feature that allows users to set their preferred time limits for making score predictions. This feature includes default time limit an enum  representation  and updated game logic to handle the scenario appropriately

## Changes Made

### 1. Timer Duration Enum
- **Created**: `TimerDuration` enum with predefined options
- **Values**: 10, 15, 20, 25, 30, 45 seconds
- **Purpose**: Provides type-safe, validated timer options and prevents invalid duration inputs


### 2. User Entity Updates
- **Added**: `timerDuration` field to User entity
- **Type**: Uses `TimerDuration` enum with `@Enumerated(EnumType.STRING)`
- **Default**: Set to `THIRTY_SECONDS` for new users
- **Storage**: Enum names stored as strings for migration safety

### 3. Settings API Endpoints
- **New Endpoint**: `PATCH /api/settings/timer-duration`
- **Functionality**: Accepts timer duration parameters from frontend
- **Validation**: Maps frontend values to appropriate enum constants
- **Response**: Returns updated user settings

### 4. Settings Service Implementation
- **New Method**: `updateTimerDuration(Long userId, String durationParam)`
- **Logic**: 
  - Validates incoming parameter against enum values
  - Maps frontend strings to `TimerDuration` enum
  - Persists updated timer setting to user entity

### 5. Game Logic Updates
- **Time Handling**: Modified game submission logic to handle  scenario where time is up
- **No Recording**: User games are NOT saved when timer expires without submission
- **Rationale**: Time up without score prediction should not count as "game played"
- **Data Integrity**: Prevents incomplete game records in database

### 6. Response Messages
- **Time up Response**: Added specific response structure for timer expiration
- **Message**: Clear indication that time limit was reached
- **User Experience**: Provides appropriate feedback for time up scenarios

## Technical Details

### Database Migration
- Added `timer_duration` column to `users` table
- Set default value for existing users
- Added enum constraint validation

## Migration Notes
- Existing users will receive default 30-second timer
- Users can update their preference via settings

## Future Enhancements
- Sound notification options for timer warnings
- Timer pause functionality for special scenarios